### PR TITLE
net.tcp.service[5222] and net.tcp.service[5269] don't work properly a…

### DIFF
--- a/zbx-ejabberd-template.xml
+++ b/zbx-ejabberd-template.xml
@@ -158,7 +158,7 @@
                     <snmp_community/>
                     <multiplier>0</multiplier>
                     <snmp_oid/>
-                    <key>net.tcp.service[5222]</key>
+                    <key>net.tcp.service[tcp,,5222]</key>
                     <delay>60</delay>
                     <history>7</history>
                     <trends>365</trends>
@@ -203,7 +203,7 @@
                     <snmp_community/>
                     <multiplier>0</multiplier>
                     <snmp_oid/>
-                    <key>net.tcp.service[5269]</key>
+                    <key>net.tcp.service[tcp,,5269]</key>
                     <delay>60</delay>
                     <history>7</history>
                     <trends>365</trends>
@@ -251,7 +251,7 @@
     </templates>
     <triggers>
         <trigger>
-            <expression>{Template App Ejabberd:net.tcp.service[5222].last()}&lt;&gt;0</expression>
+            <expression>{Template App Ejabberd:net.tcp.service[tcp,,5222].last()}&lt;&gt;0</expression>
             <name>ejabberd don't listen xmpp-client socket</name>
             <url/>
             <status>0</status>


### PR DESCRIPTION
…t zabbix 4.0 (#1)

kstka commented on 14 Mar

I have changed them to
net.tcp.service[tcp,,5222]
net.tcp.service[tcp,,5269]

Now it is fine